### PR TITLE
Docs and location

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
     # You can also specify other tool versions:
     # nodejs: "19"
     # rust: "1.64"

--- a/rctab_infrastructure/api.py
+++ b/rctab_infrastructure/api.py
@@ -100,7 +100,6 @@ def set_up_api(
     """
     api_resource_group = resources.ResourceGroup(
         f"rctab-{IDENTIFIER}-",
-        resources.ResourceGroupArgs(location="UK South"),
     )
 
     # Dedicated plan (not based on usage)

--- a/rctab_infrastructure/function_apps.py
+++ b/rctab_infrastructure/function_apps.py
@@ -231,9 +231,7 @@ def set_up_function_apps(
     """
     resource_group = resources.ResourceGroup(
         f"rctab-mngmnt-functions-{IDENTIFIER}-",
-        resources.ResourceGroupArgs(
-            location="UK South",
-        ),
+        resources.ResourceGroupArgs(),
     )
 
     account = storage.StorageAccount(

--- a/rctab_infrastructure/rctab_logging.py
+++ b/rctab_infrastructure/rctab_logging.py
@@ -26,7 +26,6 @@ def set_up_logging() -> Tuple[Output[str], Output[str], resources.ResourceGroup]
     """
     logging_resource_group = resources.ResourceGroup(
         f"rctab-central-logging-{IDENTIFIER}-",
-        location="UK South",
     )
 
     workspace = operationalinsights.Workspace(


### PR DESCRIPTION
A small PR to:

1. Use pg_restore in the db upgrade docs section, since we found psql errored with, presumably, some kind of poorly escaped special char.
2. Remove the explicit references to "UK South" as we can use the pulumi azure-native:location setting instead.
