### PR TITLE
Set minimum TLS version to 1.2 for web app and function apps

### DIFF
--- a/rctab_infrastructure/function_apps.py
+++ b/rctab_infrastructure/function_apps.py
@@ -190,6 +190,8 @@ def create_function_app(
                 + app_settings,
                 always_on=True,
                 linux_fx_version=f"DOCKER|{image_name}",
+                min_tls_version=web.SupportedTlsVersions.SUPPORTED_TLS_VERSIONS_1_2,
+                scm_min_tls_version=web.SupportedTlsVersions.SUPPORTED_TLS_VERSIONS_1_2,
             ),
             https_only=True,
         ),

--- a/rctab_infrastructure/webapp.py
+++ b/rctab_infrastructure/webapp.py
@@ -200,6 +200,8 @@ def create_webapp(
                 app_settings=app_settings,
                 always_on=True,
                 linux_fx_version=f"DOCKER|{DOCKER_API_IMAGE}",
+                min_tls_version=web.SupportedTlsVersions.SUPPORTED_TLS_VERSIONS_1_2,
+                scm_min_tls_version=web.SupportedTlsVersions.SUPPORTED_TLS_VERSIONS_1_2,
             ),
             https_only=True,
         ),


### PR DESCRIPTION
# Pull Request Description

Without an explicit min_tls_version Azure uses its default, which may not be the latest.

## Related Issue(s)

- Closes #28 

## Proposed Changes

- Both the app and SCM endpoints are now enforced to TLS 1.2 minimum.

## Reviewers

Please tag (@mention) potential reviewers or any specific team members you want to review this pull request.

## How to Test

Run `pulumi up` and confirm that we can deploy a new instance.
